### PR TITLE
Remove line-height from styling

### DIFF
--- a/stylesheets/base.less
+++ b/stylesheets/base.less
@@ -3,9 +3,6 @@
 .editor, .editor-colors {
   background-color: @syntax-background-color;
   color: @syntax-text-color;
-  .lines, .line-numbers, .cursor {
-    line-height: 1.5;
-  }
 }
 
 .editor {


### PR DESCRIPTION
Line height is now managed through the settings page, and setting it manually seems to mess with things with the React editor.
